### PR TITLE
Fix crash when pressed Back in Mass Op activity

### DIFF
--- a/app/src/main/java/ru/orangesoftware/financisto/activity/BlotterActivity.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/activity/BlotterActivity.java
@@ -597,7 +597,7 @@ public class BlotterActivity extends AbstractListActivity {
     public void onBackPressed()
     {
         FrameLayout searchLayout = findViewById(R.id.search_text_frame);
-        if (searchLayout.getVisibility() == View.VISIBLE) {
+        if (searchLayout != null && searchLayout.getVisibility() == View.VISIBLE) {
             searchLayout.setVisibility(View.GONE);
         } else {
             super.onBackPressed();


### PR DESCRIPTION
Mass Op activity does not have the search layout, so it would crash when trying to call getVisibility() on a null reference.