### PR TITLE
[#36] Avoid triggering Autofill dropdown on Add Transaction screen

### DIFF
--- a/app/src/main/res/layout/transaction_fixed.xml
+++ b/app/src/main/res/layout/transaction_fixed.xml
@@ -10,7 +10,8 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	android:layout_width="fill_parent" android:layout_height="fill_parent"
-	android:orientation="vertical">
+	android:orientation="vertical"
+	android:importantForAutofill="noExcludeDescendants">
 	<ScrollView android:layout_width="fill_parent"
 		android:layout_height="wrap_content" android:layout_weight="1">
 		<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/transaction_free.xml
+++ b/app/src/main/res/layout/transaction_free.xml
@@ -9,7 +9,8 @@
       Denis Solonenko - initial API and implementation
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-	android:layout_width="fill_parent" android:layout_height="fill_parent">
+	android:layout_width="fill_parent" android:layout_height="fill_parent"
+	android:importantForAutofill="noExcludeDescendants">
 	<LinearLayout android:layout_width="fill_parent"
 		android:layout_height="wrap_content" android:orientation="vertical">
 		<LinearLayout android:layout_height="wrap_content"


### PR DESCRIPTION
Fixes #36
I branched off of tag 1.8.1 (release that's currently in Play Store) so that it's easier to issue a hotfix.