### PR TITLE
Fix creating new payee in transaction editor

### DIFF
--- a/app/src/main/java/ru/orangesoftware/financisto/activity/AbstractTransactionActivity.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/activity/AbstractTransactionActivity.java
@@ -550,6 +550,9 @@ public abstract class AbstractTransactionActivity extends AbstractActivity imple
         projectSelector.onActivityResult(requestCode, resultCode, data);
         categorySelector.onActivityResult(requestCode, resultCode, data);
         locationSelector.onActivityResult(requestCode, resultCode, data);
+        if (isShowPayee) {
+            payeeSelector.onActivityResult(requestCode, resultCode, data);
+        }
         if (resultCode == RESULT_OK) {
             switch (requestCode) {
                 case RECURRENCE_REQUEST:


### PR DESCRIPTION
Reloads payee list after creating new payee.
Previously new created payee would not be automatically selected, nor display in the list.