### PR TITLE
Fix the cleartext error when updating currency rates

### DIFF
--- a/app/src/main/java/ru/orangesoftware/financisto/rates/FreeCurrencyRateDownloader.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/rates/FreeCurrencyRateDownloader.java
@@ -58,6 +58,6 @@ public class FreeCurrencyRateDownloader extends AbstractMultipleRatesDownloader 
     }
 
     private String buildUrl (Currency fromCurrency, Currency toCurrency) {
-        return "http://freecurrencyrates.com/api/action.php?s=fcr&iso="+toCurrency.name+"&f="+fromCurrency.name+"&v=1&do=cvals";
+        return "https://freecurrencyrates.com/api/action.php?s=fcr&iso="+toCurrency.name+"&f="+fromCurrency.name+"&v=1&do=cvals";
     }
 }

--- a/app/src/main/java/ru/orangesoftware/financisto/rates/OpenExchangeRatesDownloader.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/rates/OpenExchangeRatesDownloader.java
@@ -25,7 +25,7 @@ import ru.orangesoftware.financisto.utils.StringUtil;
 public class OpenExchangeRatesDownloader extends AbstractMultipleRatesDownloader {
 
     private static final String TAG = OpenExchangeRatesDownloader.class.getSimpleName();
-    private static final String GET_LATEST = "http://openexchangerates.org/api/latest.json?app_id=";
+    private static final String GET_LATEST = "https://openexchangerates.org/api/latest.json?app_id=";
 
     private final String appId;
     private final HttpClientWrapper httpClient;

--- a/app/src/test/java/ru/orangesoftware/financisto/rates/OpenExchangeRatesDownloaderTest.java
+++ b/app/src/test/java/ru/orangesoftware/financisto/rates/OpenExchangeRatesDownloaderTest.java
@@ -20,7 +20,7 @@ public class OpenExchangeRatesDownloaderTest extends AbstractRatesDownloaderTest
     @Test
     public void should_download_single_rate_usd_to_cur() {
         //given
-        givenResponseFromWebService("http://openexchangerates.org/api/latest.json?app_id=MY_APP_ID",
+        givenResponseFromWebService("https://openexchangerates.org/api/latest.json?app_id=MY_APP_ID",
                 "open_exchange_normal_response.json");
         //when
         ExchangeRate downloadedExchangeRate = downloadRate("USD", "SGD");

--- a/app/src/test/resources/open_exchange_normal_response.json
+++ b/app/src/test/resources/open_exchange_normal_response.json
@@ -1,6 +1,6 @@
 {
-    "disclaimer": "Exchange rates are provided for informational purposes only, and do not constitute financial advice of any kind. Although every attempt is made to ensure quality, NO guarantees are given whatsoever of accuracy, validity, availability, or fitness for any purpose - please use at your own risk. All usage is subject to your acceptance of the Terms and Conditions of Service, available at: http://openexchangerates.org/terms/",
-    "license": "Data sourced from various providers with public-facing APIs; copyright may apply; resale is prohibited; no warranties given of any kind. All usage is subject to your acceptance of the License Agreement available at: http://openexchangerates.org/license/",
+    "disclaimer": "Exchange rates are provided for informational purposes only, and do not constitute financial advice of any kind. Although every attempt is made to ensure quality, NO guarantees are given whatsoever of accuracy, validity, availability, or fitness for any purpose - please use at your own risk. All usage is subject to your acceptance of the Terms and Conditions of Service, available at: https://openexchangerates.org/terms/",
+    "license": "Data sourced from various providers with public-facing APIs; copyright may apply; resale is prohibited; no warranties given of any kind. All usage is subject to your acceptance of the License Agreement available at: https://openexchangerates.org/license/",
     "timestamp": 1361034009,
     "base": "USD",
     "rates": {


### PR DESCRIPTION
FreeCurrencyRate and OpenExchangeRates now use https to fix the Cleartext error.