### PR TITLE
Write payee for transfers in CSV export

### DIFF
--- a/app/src/main/java/ru/orangesoftware/financisto/export/csv/CsvExport.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/csv/CsvExport.java
@@ -104,13 +104,13 @@ public class CsvExport extends Export {
         Category category = getCategoryById(t.categoryId);
         Project project = getProjectById(t.projectId);
         Account fromAccount = getAccount(t.fromAccountId);
+        Payee payee = getPayee(t.payeeId);
         if (t.isTransfer()) {
             Account toAccount = getAccount(t.toAccountId);
-            writeLine(w, dt, fromAccount.title, t.fromAmount, fromAccount.currency.id, 0, 0, category, null, TRANSFER_OUT, project, t.note);
-            writeLine(w, dt, toAccount.title, t.toAmount, toAccount.currency.id, 0, 0, category, null, TRANSFER_IN, project, t.note);
+            writeLine(w, dt, fromAccount.title, t.fromAmount, fromAccount.currency.id, 0, 0, category, payee, TRANSFER_OUT, project, t.note);
+            writeLine(w, dt, toAccount.title, t.toAmount, toAccount.currency.id, 0, 0, category, payee, TRANSFER_IN, project, t.note);
         } else {
             MyLocation location = getLocationById(t.locationId);
-            Payee payee = getPayee(t.payeeId);
             writeLine(w, dt, fromAccount.title, t.fromAmount, fromAccount.currency.id, t.originalFromAmount, t.originalCurrencyId,
                     category, payee, location, project, t.note);
             if (category != null && category.isSplit() && options.exportSplits) {

--- a/app/src/test/java/ru/orangesoftware/financisto/export/CsvExportTest.java
+++ b/app/src/test/java/ru/orangesoftware/financisto/export/CsvExportTest.java
@@ -99,8 +99,8 @@ public class CsvExportTest extends AbstractExportTest<CsvExport, CsvExportOption
                 .create();
         assertEquals(
                 "2011-08-03,22:34:55,My Cash Account,-5.00,SGD,\"\",\"\",SPLIT,\"\",P1,Home,R1,My note\n"+
-                        "~,\"\",My Cash Account,-5.00,SGD,\"\",\"\",\"\",\"\",\"\",Transfer Out,<NO_PROJECT>,\n"+
-                        "~,\"\",My Bank Account,1.00,CZK,\"\",\"\",\"\",\"\",\"\",Transfer In,<NO_PROJECT>,\n",
+                        "~,\"\",My Cash Account,-5.00,SGD,\"\",\"\",\"\",\"\",P1,Transfer Out,<NO_PROJECT>,\n"+
+                        "~,\"\",My Bank Account,1.00,CZK,\"\",\"\",\"\",\"\",P1,Transfer In,<NO_PROJECT>,\n",
                 exportAsString(options));
     }
 


### PR DESCRIPTION
Fixes #143 

As far as tests go, I decided to only update the expected result(-s) without updating any of the actuals. In particular:
- `should_export_regular_transfer` did not have a payee in its test transaction,
  so it stayed the same
- `should_export_split_transfer` had a payee, meaning the export result should
  have it as well from now on