### PR TITLE
export: add status field in CSV export

### DIFF
--- a/app/src/main/java/ru/orangesoftware/financisto/export/csv/CsvExport.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/csv/CsvExport.java
@@ -31,7 +31,7 @@ import static ru.orangesoftware.financisto.datetime.DateUtils.FORMAT_TIME_ISO_86
 
 public class CsvExport extends Export {
 
-    static final String[] HEADER = "date,time,account,amount,currency,original amount,original currency,category,parent,payee,location,project,note".split(",");
+    static final String[] HEADER = "date,time,account,amount,currency,original amount,original currency,category,parent,payee,location,project,note,status".split(",");
 
     private static final MyLocation TRANSFER_IN = new MyLocation();
     private static final MyLocation TRANSFER_OUT = new MyLocation();
@@ -106,13 +106,13 @@ public class CsvExport extends Export {
         Account fromAccount = getAccount(t.fromAccountId);
         if (t.isTransfer()) {
             Account toAccount = getAccount(t.toAccountId);
-            writeLine(w, dt, fromAccount.title, t.fromAmount, fromAccount.currency.id, 0, 0, category, null, TRANSFER_OUT, project, t.note);
-            writeLine(w, dt, toAccount.title, t.toAmount, toAccount.currency.id, 0, 0, category, null, TRANSFER_IN, project, t.note);
+            writeLine(w, dt, fromAccount.title, t.fromAmount, fromAccount.currency.id, 0, 0, category, null, TRANSFER_OUT, project, t.note, t.status);
+            writeLine(w, dt, toAccount.title, t.toAmount, toAccount.currency.id, 0, 0, category, null, TRANSFER_IN, project, t.note, t.status);
         } else {
             MyLocation location = getLocationById(t.locationId);
             Payee payee = getPayee(t.payeeId);
             writeLine(w, dt, fromAccount.title, t.fromAmount, fromAccount.currency.id, t.originalFromAmount, t.originalCurrencyId,
-                    category, payee, location, project, t.note);
+                    category, payee, location, project, t.note, t.status);
             if (category != null && category.isSplit() && options.exportSplits) {
                 List<Transaction> splits = db.getSplitsForTransaction(t.id);
                 for (Transaction split : splits) {
@@ -126,7 +126,8 @@ public class CsvExport extends Export {
     private void writeLine(Csv.Writer w, Date dt, String account,
                            long amount, long currencyId,
                            long originalAmount, long originalCurrencyId,
-                           Category category, Payee payee, MyLocation location, Project project, String note) {
+                           Category category, Payee payee, MyLocation location, Project project, String note,
+                           TransactionStatus status) {
         if (dt != null) {
             w.value(FORMAT_DATE_ISO_8601.format(dt));
             w.value(FORMAT_TIME_ISO_8601.format(dt));
@@ -154,6 +155,7 @@ public class CsvExport extends Export {
         w.value(location != null ? location.title : "");
         w.value(project != null ? project.title : "");
         w.value(note);
+        w.value(Integer.toString(status.ordinal()));
         w.newLine();
     }
 

--- a/app/src/main/java/ru/orangesoftware/financisto/export/csv/CsvImport.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/csv/CsvImport.java
@@ -29,6 +29,7 @@ import ru.orangesoftware.financisto.model.Payee;
 import ru.orangesoftware.financisto.model.Project;
 import ru.orangesoftware.financisto.model.Transaction;
 import ru.orangesoftware.financisto.model.TransactionAttribute;
+import ru.orangesoftware.financisto.model.TransactionStatus;
 import ru.orangesoftware.financisto.utils.Utils;
 
 public class CsvImport {
@@ -217,6 +218,26 @@ public class CsvImport {
                                             throw new ImportExportException(R.string.import_wrong_currency_2, null, fieldValue);
                                         }
                                         transaction.currency = fieldValue;
+                                    } else if (transactionField.equals("status")) {
+                                        int ordinal = 0;
+                                        try {
+                                            ordinal = Integer.parseInt(fieldValue);
+                                        } catch (NumberFormatException ex) {
+                                            throw new ImportExportException(R.string.import_wrong_status_string, ex, fieldValue);
+                                        }
+                                        if (ordinal == TransactionStatus.RS.ordinal()) {
+                                            transaction.status = TransactionStatus.RS;
+                                        } else if (ordinal == TransactionStatus.PN.ordinal()) {
+                                            transaction.status = TransactionStatus.PN;
+                                        } else if (ordinal == TransactionStatus.UR.ordinal()) {
+                                            transaction.status = TransactionStatus.UR;
+                                        } else if (ordinal == TransactionStatus.CL.ordinal()) {
+                                            transaction.status = TransactionStatus.CL;
+                                        } else if (ordinal == TransactionStatus.RC.ordinal()) {
+                                            transaction.status = TransactionStatus.RC;
+                                        } else {
+                                            throw new ImportExportException(R.string.import_wrong_status_ordinal, null, Integer.toString(ordinal));
+                                        }
                                     }
                                 }
                             } catch (IllegalArgumentException e) {

--- a/app/src/main/java/ru/orangesoftware/financisto/export/csv/CsvTransaction.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/csv/CsvTransaction.java
@@ -31,6 +31,7 @@ public class CsvTransaction {
     public String project;
     public String currency;
     public long delta;
+    public TransactionStatus status = TransactionStatus.UR;
 
     Transaction createTransaction(Map<String, Currency> currencies, Map<String, Category> categories, Map<String, Project> projects, Map<String, Payee> payees) {
         Transaction t = new Transaction();
@@ -46,6 +47,7 @@ public class CsvTransaction {
             t.originalCurrencyId = currency.id;
         }
         t.note = note;
+        t.status = status;
         return t;
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -680,6 +680,8 @@
     <string name="import_illegal_argument_exception">Illegal argument exception</string>
     <string name="import_parse_error">Parsing error in import file</string>
     <string name="csv_import_error">CSV import error</string>
+    <string name="import_wrong_status_string">Cannot parse status string</string>
+    <string name="import_wrong_status_ordinal">Wrong status ordinal value</string>
 
     <string name="qif_import">QIF Import</string>
     <string name="qif_import_inprogress">Importing data from QIF…</string>

--- a/app/src/test/java/ru/orangesoftware/financisto/export/CsvExportTest.java
+++ b/app/src/test/java/ru/orangesoftware/financisto/export/CsvExportTest.java
@@ -48,7 +48,7 @@ public class CsvExportTest extends AbstractExportTest<CsvExport, CsvExportOption
     @Test
     public void should_include_header() throws Exception {
         CsvExportOptions options = new CsvExportOptions(Currency.EMPTY, ',', true, false, false, WhereFilter.empty(), false);
-        assertEquals("date,time,account,amount,currency,original amount,original currency,category,parent,payee,location,project,note\n", exportAsString(options));
+        assertEquals("date,time,account,amount,currency,original amount,original currency,category,parent,payee,location,project,note,status\n", exportAsString(options));
     }
 
     @Test
@@ -59,8 +59,8 @@ public class CsvExportTest extends AbstractExportTest<CsvExport, CsvExportOption
         TransactionBuilder.withDb(db).dateTime(DateTime.date(2011, 8, 4).at(23, 34, 55, 10))
                 .account(a1).amount(-789).originalAmount(a2.currency, -888).category(categoriesMap.get("AA1")).payee("P1").location("Home").project("P1").note("My note").create();
         assertEquals(
-                "2011-08-04,23:34:55,My Cash Account,-7.89,SGD,-8.88,CZK,AA1,A:A1,P1,Home,P1,My note\n"+
-                "2011-08-03,22:34:55,My Cash Account,-1234.56,SGD,\"\",\"\",AA1,A:A1,P1,Home,P1,My note\n",
+                "2011-08-04,23:34:55,My Cash Account,-7.89,SGD,-8.88,CZK,AA1,A:A1,P1,Home,P1,My note,2\n"+
+                "2011-08-03,22:34:55,My Cash Account,-1234.56,SGD,\"\",\"\",AA1,A:A1,P1,Home,P1,My note,2\n",
                 exportAsString(options));
     }
 
@@ -70,8 +70,8 @@ public class CsvExportTest extends AbstractExportTest<CsvExport, CsvExportOption
         TransferBuilder.withDb(db).dateTime(DateTime.date(2011, 8, 3).at(22, 46, 0, 0))
                 .fromAccount(a1).fromAmount(-450000).toAccount(a2).toAmount(25600).create();
         assertEquals(
-                "2011-08-03,22:46:00,My Cash Account,-4500.00,SGD,\"\",\"\",\"\",\"\",\"\",Transfer Out,<NO_PROJECT>,\n"+
-                "2011-08-03,22:46:00,My Bank Account,256.00,CZK,\"\",\"\",\"\",\"\",\"\",Transfer In,<NO_PROJECT>,\n",
+                "2011-08-03,22:46:00,My Cash Account,-4500.00,SGD,\"\",\"\",\"\",\"\",\"\",Transfer Out,<NO_PROJECT>,,2\n"+
+                "2011-08-03,22:46:00,My Bank Account,256.00,CZK,\"\",\"\",\"\",\"\",\"\",Transfer In,<NO_PROJECT>,,2\n",
                 exportAsString(options));
     }
 
@@ -84,9 +84,9 @@ public class CsvExportTest extends AbstractExportTest<CsvExport, CsvExportOption
                 .withSplit(categoriesMap.get("A2"), -1500)
                 .create();
         assertEquals(
-                "2011-08-03,22:34:55,My Cash Account,-20.00,SGD,\"\",\"\",SPLIT,\"\",P1,Home,R1,My note\n"+
-                "~,\"\",My Cash Account,-5.00,SGD,\"\",\"\",A1,A,P1,\"\",<NO_PROJECT>,\n"+
-                "~,\"\",My Cash Account,-15.00,SGD,\"\",\"\",A2,A,P1,\"\",<NO_PROJECT>,\n",
+                "2011-08-03,22:34:55,My Cash Account,-20.00,SGD,\"\",\"\",SPLIT,\"\",P1,Home,R1,My note,2\n"+
+                "~,\"\",My Cash Account,-5.00,SGD,\"\",\"\",A1,A,P1,\"\",<NO_PROJECT>,,2\n"+
+                "~,\"\",My Cash Account,-15.00,SGD,\"\",\"\",A2,A,P1,\"\",<NO_PROJECT>,,2\n",
                 exportAsString(options));
     }
 
@@ -98,9 +98,9 @@ public class CsvExportTest extends AbstractExportTest<CsvExport, CsvExportOption
                 .withTransferSplit(a2, -500, +100)
                 .create();
         assertEquals(
-                "2011-08-03,22:34:55,My Cash Account,-5.00,SGD,\"\",\"\",SPLIT,\"\",P1,Home,R1,My note\n"+
-                        "~,\"\",My Cash Account,-5.00,SGD,\"\",\"\",\"\",\"\",\"\",Transfer Out,<NO_PROJECT>,\n"+
-                        "~,\"\",My Bank Account,1.00,CZK,\"\",\"\",\"\",\"\",\"\",Transfer In,<NO_PROJECT>,\n",
+                "2011-08-03,22:34:55,My Cash Account,-5.00,SGD,\"\",\"\",SPLIT,\"\",P1,Home,R1,My note,2\n"+
+                        "~,\"\",My Cash Account,-5.00,SGD,\"\",\"\",\"\",\"\",\"\",Transfer Out,<NO_PROJECT>,,2\n"+
+                        "~,\"\",My Bank Account,1.00,CZK,\"\",\"\",\"\",\"\",\"\",Transfer In,<NO_PROJECT>,,2\n",
                 exportAsString(options));
     }
 
@@ -113,7 +113,7 @@ public class CsvExportTest extends AbstractExportTest<CsvExport, CsvExportOption
                 .withSplit(categoriesMap.get("A2"), -1500)
                 .create();
         assertEquals(
-                "2011-08-03,22:34:55,My Cash Account,-20.00,SGD,\"\",\"\",SPLIT,\"\",P1,Home,R1,My note\n",
+                "2011-08-03,22:34:55,My Cash Account,-20.00,SGD,\"\",\"\",SPLIT,\"\",P1,Home,R1,My note,2\n",
                 exportAsString(options));
     }
 


### PR DESCRIPTION
Status is an important field while doing accounting review, especially there are credit card or band account which are verified periodically. Sometimes there are interleaving unreconciled and reconciled records for credit card or bank account in a month review, including the status field would be helpful to exclude those reconciled records.