### PR TITLE
test: write data to a file in correct encoding

### DIFF
--- a/app/src/test/java/ru/orangesoftware/financisto/backup/LegacyDatabaseRestoreTest.java
+++ b/app/src/test/java/ru/orangesoftware/financisto/backup/LegacyDatabaseRestoreTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import ru.orangesoftware.financisto.db.AbstractDbTest;
@@ -272,7 +273,7 @@ public class LegacyDatabaseRestoreTest extends AbstractDbTest {
     private String createBackupFile(String fileContent) throws IOException {
         String fileName = "backup_" + System.currentTimeMillis() + ".backup";
         FileOutputStream out = new FileOutputStream(new File(Export.getBackupFolder(getContext()), fileName));
-        out.write(fileContent.getBytes());
+        out.write(fileContent.getBytes(StandardCharsets.UTF_8));
         out.flush();
         out.close();
         return fileName;


### PR DESCRIPTION
Fixes #148
The encoding is not set on writing data, it leads to test failures with a locale different from the original one.